### PR TITLE
fix: missing comma introduced in #4

### DIFF
--- a/.luacheckrc.template
+++ b/.luacheckrc.template
@@ -75,7 +75,7 @@ stds.cfx_sv = {
         "GetPlayerTokens",
         "PerformHttpRequest",
         "CreateVehicle",
-        "CreateVehicleServerSetter"
+        "CreateVehicleServerSetter",
         %%SERVER_GLOBALS%%
     }
 }


### PR DESCRIPTION
This PR fixes a missing comma introduced in #4 which subsequently causes the linter to fail

![image](https://user-images.githubusercontent.com/96954031/196661502-fc63c22d-b0f2-45aa-9f6c-64c4167fc96b.png)
