### PR TITLE
feat: esx globals

### DIFF
--- a/.luacheckrc.template
+++ b/.luacheckrc.template
@@ -128,19 +128,14 @@ stds.cfx_manifest = {
     },
 }
 
-stds.esx_legacy = {
+stds.esx = {
     read_globals = {
-        MySQL = {
-            fields = {
-                "ready",
-                "insert",
-                "update",
-                "scalar",
-                "single",
-                "prepare",
-                "query",
-            }
-        }
+        "ESX",
+        "Locales",
+        "_",
+        "_U",
+        "Translate",
+        "TranslateCap"
     }
 }
 


### PR DESCRIPTION
Add `ESX` from [@es_extended/imports.lua](https://github.com/esx-framework/esx_core/blob/main/%5Bcore%5D/es_extended/imports.lua) and `Locales`, `_`, `_U`, `Translate`, and `TranslateCap` from [@es_extended/locale.lua](https://github.com/esx-framework/esx_core/blob/main/%5Bcore%5D/es_extended/locale.lua)