### PR TITLE
feat: Add ox_lib globals

### DIFF
--- a/.luacheckrc.template
+++ b/.luacheckrc.template
@@ -181,6 +181,130 @@ stds.mysql = {
     }
 }
 
+stds.oxlib = {
+    read_globals = {
+        "cache",
+        "locale",
+        lib = {
+            fields = {
+                "alertDialog",
+                "closeAlertDialog",
+                "setClipboard",
+                "registerContext",
+                "showContext",
+                "hideContext",
+                "getOpenContextMenu",
+                "inputDialog",
+                "closeInputDialog",
+                "registerMenu",
+                "showMenu",
+                "hideMenu",
+                "getOpenMenu",
+                "setMenuOptions",
+                "notify",
+                "progressBar",
+                "progressCircle",
+                "progressActive",
+                "cancelProgress",
+                "addRadialItem",
+                "removeRadialItem",
+                "clearRadialItems",
+                "registerRadial",
+                "hideRadial",
+                "disableRadial",
+                "getCurrentRadialId",
+                "skillCheck",
+                "skillCheckActive",
+                "cancelSkillCheck",
+                "showTextUI",
+                "hideTextUI"
+                "isTextUIOpen",
+                "addAce",
+                "removeAce",
+                "addPrincipal",
+                "removePrincipal",
+                "addCommand",
+                "addKeybind",
+                "onCache",
+                "cache",
+                callback = {
+                    fields = {
+                        "await",
+                        "register"
+                    }
+                },
+                cron = {
+                    fields = {
+                        "new"
+                    }
+                },
+                "disableControls",
+                "getClosestObject",
+                "getClosestPed",
+                "getClosestPlayer",
+                "getClosestVehicle",
+                "getNearbyObjects",
+                "getNearbyPeds",
+                "getNearbyPlayers",
+                "getNearbyVehicles",
+                "locale",
+                "logger",
+                math = {
+                    fields = {
+                        "toscalars",
+                        "tovector",
+                        "torgba",
+                        "tohex",
+                        "groupdigits"
+                    }
+                },
+                points = {
+                    fields = {
+                        "new",
+                        "getAllPoints",
+                        "getNearbyPoints",
+                        "getClosestPoint",
+                    }
+                },
+                raycast = {
+                    fields = {
+                        "cam"
+                    }
+                },
+                "requestAnimDict",
+                "requestAnimSet",
+                "requestModel",
+                "requestStreamedTextureDict",
+                "requestNamedPtfxAsset",
+                "requestScaleformMovie",
+                "requestWeaponAsset",
+                table = {
+                    fields = {
+                        "contains",
+                        "matches",
+                        "deepclone",
+                        "merge",
+                        "freeze",
+                        "isFrozen"
+                    }
+                },
+                "getVehicleProperties",
+                "setVehicleProperties",
+                "versionCheck",
+                "checkDependency",
+                "waitFor",
+                zones = {
+                    fields = {
+                        "poly",
+                        "box",
+                        "sphere"
+                    }
+                }
+            }
+        }
+    }
+}
+
 stds.polyzone = {
     read_globals = {
         "PolyZone",

--- a/.luacheckrc.template
+++ b/.luacheckrc.template
@@ -217,7 +217,7 @@ stds.oxlib = {
                 "skillCheckActive",
                 "cancelSkillCheck",
                 "showTextUI",
-                "hideTextUI"
+                "hideTextUI",
                 "isTextUIOpen",
                 "addAce",
                 "removeAce",


### PR DESCRIPTION
Does what it says in the title. Tested it on qbx-truckerjob, and ox_lib globals no longer throw linter errors.

If anyone wants to do more extensive testing, feel free to do so and share your results, although everything should be working as intended. Used https://overextended.dev/ox_lib as reference.

Here's a release tag if anyone wants to test the action:
https://github.com/myshkovsky/fivem-lua-lint-action/releases/tag/test