### PR TITLE
fix(libs): math and string can be written to

### DIFF
--- a/.luacheckrc.template
+++ b/.luacheckrc.template
@@ -154,6 +154,20 @@ stds.qbox_playerdata = {
 }
 
 stds.qbox_utils = {
+    globals = {
+        math = {
+            fields = {
+                "round"
+            }
+        },
+        string = {
+            fields = {
+                "split",
+                "trim",
+                "firstToUpper"
+            }
+        },
+    },
     read_globals = {
         "GetCoordsFromEntity",
         "GetPlate",
@@ -163,19 +177,7 @@ stds.qbox_utils = {
         "RandomNumber",
         "RandomNumberOrLetter",
         "GenerateRandomPlate",
-        "HasItem",
-        string = {
-            fields = {
-                "split",
-                "trim",
-                "firstToUpper"
-            }
-        },
-        math = {
-            fields = {
-                "round"
-            }
-        }
+        "HasItem"
     }
 }
 


### PR DESCRIPTION
![image](https://github.com/iLLeniumStudios/fivem-lua-lint-action/assets/82737367/7a5618c4-8ca1-490c-88d3-b6d940c87055)
Should fix this issue on qbx-core