### PR TITLE
feat: add `rawExecute` to mysql template

### DIFF
--- a/.luacheckrc.template
+++ b/.luacheckrc.template
@@ -239,6 +239,7 @@ stds.mysql = {
                 "query",
                 "update",
                 "scalar",
+                "rawExecute",
                 "single",
                 "insert",
                 "transaction",


### PR DESCRIPTION
Seems like the `MySQL.rawExecute` function is missing from the template structure
Which caused repos such as qb-banking, and so on, to fail, hence why I noticed it.
So this PR just aims to add that.

https://overextended.dev/oxmysql/Functions/rawExecute
https://github.com/qbcore-framework/qb-banking/runs/20244591752