### PR TITLE
chore(luachecktemplate): move source to shared

### DIFF
--- a/.luacheckrc.template
+++ b/.luacheckrc.template
@@ -83,6 +83,7 @@ stds.cfx = {
         "quat",
         "qua",
         "joaat",
+        "source",
         %%SHARED_GLOBALS%%
     }
 }
@@ -90,7 +91,6 @@ stds.cfx = {
 stds.cfx_sv = {
     globals = { "GlobalState" },
     read_globals = {
-        "source",
         "TriggerClientEvent",
         "TriggerLatentClientEvent",
         "RegisterServerEvent",


### PR DESCRIPTION
This is actually available on both client and server instead of only server